### PR TITLE
[fix] Wouldn't build due to missing src/sailfish_main.cpp

### DIFF
--- a/sailfish/harbour-kaktus.pro
+++ b/sailfish/harbour-kaktus.pro
@@ -8,7 +8,8 @@ DEFINES += SAILFISH
 DEFINES += ONLINE_CHECK
 
 SOURCES += \
-    src/main_sailfish.cpp \
+    src/main.cpp \
+    src/ai.cpp \
     src/utils.cpp \
     src/tabmodel.cpp \
     src/listmodel.cpp \
@@ -30,6 +31,7 @@ SOURCES += \
     src/iconprovider.cpp
 
 HEADERS += \
+    src/ai.h \
     src/utils.h \
     src/tabmodel.h \
     src/listmodel.h \


### PR DESCRIPTION
It was renamed to src/main.cpp in 79725af21a7961f67bb56830b5174d0f2df59c7e.

I also needed to add the Pocket stuff from 869e12a0fd8e6149bf669e164fe2cb00b510e8d6.