### PR TITLE
Add support for inverted orientations

### DIFF
--- a/sailfish/qml/AboutPage.qml
+++ b/sailfish/qml/AboutPage.qml
@@ -28,11 +28,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/AccountsDialog.qml
+++ b/sailfish/qml/AccountsDialog.qml
@@ -28,11 +28,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/AuthWebViewPage.qml
+++ b/sailfish/qml/AuthWebViewPage.qml
@@ -65,11 +65,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     SilicaWebView {

--- a/sailfish/qml/ChangelogPage.qml
+++ b/sailfish/qml/ChangelogPage.qml
@@ -28,11 +28,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/ControlBar.qml
+++ b/sailfish/qml/ControlBar.qml
@@ -43,7 +43,7 @@ Item {
     property Flickable flick: null
 
     // other
-    readonly property bool isPortrait: app.orientation === Orientation.Portrait
+    readonly property bool isPortrait: app.orientation == Orientation.Portrait || app.orientation == Orientation.PortraitInverted
     readonly property int stdHeight: isPortrait ? Theme.itemSizeMedium : 0.8 * Theme.itemSizeMedium
 
     height: root.stdHeight

--- a/sailfish/qml/DashboardDialog.qml
+++ b/sailfish/qml/DashboardDialog.qml
@@ -29,11 +29,11 @@ Dialog {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/DashboardPage.qml
+++ b/sailfish/qml/DashboardPage.qml
@@ -29,11 +29,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/DebugPage.qml
+++ b/sailfish/qml/DebugPage.qml
@@ -28,11 +28,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/EntryPage.qml
+++ b/sailfish/qml/EntryPage.qml
@@ -28,11 +28,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     property bool showBar: true

--- a/sailfish/qml/FeedPage.qml
+++ b/sailfish/qml/FeedPage.qml
@@ -32,11 +32,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     property string title

--- a/sailfish/qml/FeedWebContentPage.qml
+++ b/sailfish/qml/FeedWebContentPage.qml
@@ -70,11 +70,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     Component.onCompleted: {

--- a/sailfish/qml/FirstPage.qml
+++ b/sailfish/qml/FirstPage.qml
@@ -29,11 +29,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     SilicaListView {

--- a/sailfish/qml/NvSignInDialog.qml
+++ b/sailfish/qml/NvSignInDialog.qml
@@ -32,11 +32,11 @@ Dialog {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/OldReaderSignInDialog.qml
+++ b/sailfish/qml/OldReaderSignInDialog.qml
@@ -31,11 +31,11 @@ Dialog {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/PocketAuthWebViewPage.qml
+++ b/sailfish/qml/PocketAuthWebViewPage.qml
@@ -46,11 +46,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     onStatusChanged: {

--- a/sailfish/qml/PocketDialog.qml
+++ b/sailfish/qml/PocketDialog.qml
@@ -45,11 +45,11 @@ Dialog {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     onAccepted: {

--- a/sailfish/qml/ReadAllDialog.qml
+++ b/sailfish/qml/ReadAllDialog.qml
@@ -30,11 +30,11 @@ Dialog {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/SettingsPage.qml
+++ b/sailfish/qml/SettingsPage.qml
@@ -28,11 +28,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/ShareDialog.qml
+++ b/sailfish/qml/ShareDialog.qml
@@ -33,11 +33,11 @@ Dialog {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/SignOutDialog.qml
+++ b/sailfish/qml/SignOutDialog.qml
@@ -29,11 +29,11 @@ Dialog {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/TTRssSignInDialog.qml
+++ b/sailfish/qml/TTRssSignInDialog.qml
@@ -32,11 +32,11 @@ Dialog {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/TabPage.qml
+++ b/sailfish/qml/TabPage.qml
@@ -31,11 +31,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait
+        return Orientation.All;
     }
 
     ActiveDetector {

--- a/sailfish/qml/UnreadAllDialog.qml
+++ b/sailfish/qml/UnreadAllDialog.qml
@@ -30,11 +30,11 @@ Dialog {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     ActiveDetector {}

--- a/sailfish/qml/WebPreviewPage.qml
+++ b/sailfish/qml/WebPreviewPage.qml
@@ -189,11 +189,11 @@ Page {
     allowedOrientations: {
         switch (settings.allowedOrientations) {
         case 1:
-            return Orientation.Portrait;
+            return Orientation.PortraitMask;
         case 2:
-            return Orientation.Landscape;
+            return Orientation.LandscapeMask;
         }
-        return Orientation.Landscape | Orientation.Portrait;
+        return Orientation.All;
     }
 
     Component.onCompleted: init()


### PR DESCRIPTION
Hi,

On Gemini PDA the natural screen orientation is LandscapeInverted but Kaktus would not allow inverted orientations thus this little patch.