### PR TITLE
Fix for mark as read/unread + proposal for gesture feature

### DIFF
--- a/sailfish/qml/EntryDelegate.qml
+++ b/sailfish/qml/EntryDelegate.qml
@@ -516,4 +516,69 @@ ListItem {
             }
         }
     }
+
+    drag.target: box
+    drag.axis: Drag.XAxis
+    drag.minimumX: -width
+    drag.maximumX: 0
+
+    drag.onActiveChanged: {
+        if (!drag.active) {
+            if (box.x < -width / 3) {
+                state = "toggleRead"
+            } else {
+                state = "default"
+            }
+        }
+    }
+
+    state: "default"
+
+    states: [
+        State {
+            name: "default"
+        },
+        State {
+            name: "dragging"
+            when: drag.active
+        },
+        State {
+            name: "toggleRead"
+        }
+    ]
+
+    transitions: [
+        Transition {
+            from: "dragging"
+            to: "default"
+            NumberAnimation {
+                target: box
+                properties: "x"
+                to: 0
+                duration: 200
+            }
+        },
+        Transition {
+            from: "dragging"
+            to: "toggleRead"
+            SequentialAnimation {
+                ScriptAction {
+                    script: {
+                        if (root.read) {
+                            root.markedAsUnread()
+                        } else {
+                            root.markedAsRead();
+                            root.expanded = false;
+                        }
+                    }
+                }
+                NumberAnimation {
+                    target: box
+                    properties: "x"
+                    to: 0
+                    duration: 200
+                }
+            }
+        }
+    ]
 }

--- a/sailfish/qml/EntryPage.qml
+++ b/sailfish/qml/EntryPage.qml
@@ -241,7 +241,6 @@ Page {
             offlineurl: cserver.getUrlbyId(model.uid)
 
             signal singleEntryClicked
-            signal doubleEntryClicked
 
             function check() {
                 // Not allowed while Syncing
@@ -337,16 +336,11 @@ Page {
             }
 
             onClicked: {
-                if (timer.running) {
-                    // Double click
-                    timer.stop()
-                    doubleEntryClicked()
-                } else {
-                    timer.start()
-                }
+                timer.start()
             }
 
-            onDoubleEntryClicked: {
+            onDoubleClicked: {
+                timer.stop()
                 if (model.read === 0) {
                     entryModel.setData(model.index, "read", 1, "")
                     //read = 1;
@@ -369,7 +363,7 @@ Page {
 
             Timer {
                 id: timer
-                interval: 400
+                interval: 200
                 onTriggered: {
                     // Single click
                     singleEntryClicked()

--- a/sailfish/qml/main.qml
+++ b/sailfish/qml/main.qml
@@ -450,8 +450,9 @@ ApplicationWindow {
             switch (app.orientation) {
             case Orientation.Portrait: return 0;
             case Orientation.Landscape: return 90;
-            case Orientation.PortraitInverted: 180;
-            case Orientation.LandscapeInverted: 270;
+            case Orientation.PortraitInverted: return 180;
+            case Orientation.LandscapeInverted: return 270;
+            }
         }
 
         transformOrigin: Item.TopLeft


### PR DESCRIPTION
Hi,

After updating to sfos 4.0.1 the double click feature to mark as read was broken: the second click event would not register.
By using the onDoubleClick event from MouseArea it seems to work as intended.

The second commit is a proposal for another way to mark an entry as read: flick it to the left. I have failed several times to properly double click and ended up loading the entry's content which was frustrating. What do you think?